### PR TITLE
Add drink overlay + main screen edits 

### DIFF
--- a/components/AddDrink.tsx
+++ b/components/AddDrink.tsx
@@ -102,8 +102,10 @@ const AddDrinkModal = ({ open, onClose, onAdd }: AddDrinkModalProps) => {
         <Modal visible={open} animationType="slide" transparent>
             {/* These 2 pressable's make it so we can tap outside the add drink overlay to exit it */}
             <Pressable onPress={onClose} className="flex-1 justify-center items-center bg-black/60 px-4">
-                <Pressable onPress={() => {}} className="bg-slate-800 p-6 rounded-2xl w-full max-w-xl border border-slate-700 space-y-4">
-
+                <Pressable
+                    onPress={() => {}}
+                    className="bg-slate-800 p-6 rounded-2xl w-full max-w-xl max-h-[90%] h-[80%] border border-slate-700 space-y-4"
+                >
                     {/* Header */}
                     <Text className="text-white text-lg font-bold text-center">Add Drink</Text>
 
@@ -188,8 +190,8 @@ const AddDrinkModal = ({ open, onClose, onAdd }: AddDrinkModalProps) => {
 
                     {/* Action Buttons */}
                     <View className="flex-row justify-between pt-4">
-                        <Pressable onPress={onClose}>
-                            <Text className="text-slate-400">Cancel</Text>
+                        <Pressable onPress={onClose} className="px-4 py-2 rounded-full bg-red-600" >
+                            <Text className="text-white">Cancel</Text>
                         </Pressable>
                         <Pressable
                             onPress={handleSubmit}
@@ -197,14 +199,14 @@ const AddDrinkModal = ({ open, onClose, onAdd }: AddDrinkModalProps) => {
                                 (activeTab === 'preset' && !selectedPreset) ||
                                 (activeTab === 'custom' && (!customName || !customCaffeine))
                                     ? 'bg-slate-600'
-                                    : 'bg-purple-600'
+                                    : 'bg-blue-600'
                             }`}
                             disabled={
                                 (activeTab === 'preset' && !selectedPreset) ||
                                 (activeTab === 'custom' && (!customName || !customCaffeine))
                             }
                         >
-                            <Text className="text-white font-semibold">Add Drink</Text>
+                            <Text className="text-white font-semibold">+ Add Drink</Text>
                         </Pressable>
                     </View>
                 </Pressable>

--- a/components/RecentDrinks.tsx
+++ b/components/RecentDrinks.tsx
@@ -48,10 +48,10 @@ const RecentDrinks = ({ drinks }: RecentDrinksProps) => {
     return (
         <Card className="bg-slate-800 border-slate-700">
             <CardHeader className="pb-3">
-                <CardTitle className="text-lg flex-row items-center gap-2 text-white">
-                    <Clock className="w-5 h-5 text-blue-400" />
+                <View className="flex-row items-center gap-2">
+                    <Clock color= "white" className="w-5 h-5" />
                     <Text className="text-white text-lg font-semibold">Recent Drinks</Text>
-                </CardTitle>
+                </View>
             </CardHeader>
             <CardContent className="pt-0">
                 <View className="space-y-3">


### PR DESCRIPTION
Add drink overlay edits: 
Making add drink button the same as the outside add drink button, instead of purple it is blue now. 
Made the cancel button background red and the text white. 
Made the size of the overlay larger to take up more of the screen so it is easier for the user to navigate.

Main screen edits:  
Aligned clock and recent drinks text and made the clock colour white instead of the default black.
