### PR TITLE
Fixed white flashing on screen during page transition

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,8 +1,17 @@
 import { Stack } from "expo-router";
 import "./globals.css";
+import { View } from "react-native";
 
 export default function RootLayout() {
-  return <Stack screenOptions={{
-    headerShown: false,
-  }} />;
+  return (
+    <View style={{ flex: 1, backgroundColor: '#0f172a' }}>
+      <Stack 
+        screenOptions={{
+          headerShown: false,
+          contentStyle: { backgroundColor: '#0f172a' },
+          animation: "slide_from_right",
+        }} 
+      />
+    </View>
+  );
 }


### PR DESCRIPTION
fix: White screen flash during navigation transitions

- Added root-level background color in _layout.tsx by wrapping Stack 
  with a View component
- Set consistent dark background (bg-slate-900) at the root navigation level
- Fixed navigation transition flash by ensuring proper background color 
  hierarchy

This change resolves the white screen flash that was occurring during 
navigation transitions between screens by ensuring the root navigation 
container maintains the correct background color.